### PR TITLE
fix quotes in generated environment deactivation scripts

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -272,7 +272,7 @@ class EnvVars:
                 set foundenvvar=
                 for /f "delims== tokens=1,2" %%a in ('set') do (
                     if /I "%%a" == "%%v" (
-                        echo set %%a=%%b>> "deactivate_{filename}"
+                        echo set "%%a=%%b">> "deactivate_{filename}"
                         set foundenvvar=1
                     )
                 )
@@ -290,7 +290,7 @@ class EnvVars:
         result = [capture]
         for varname, varvalues in self._values.items():
             value = varvalues.get_str("%{name}%", subsystem=self._subsystem, pathsep=self._pathsep)
-            result.append('set {}={}'.format(varname, value))
+            result.append('set "{}={}"'.format(varname, value))
 
         content = "\n".join(result)
         save(filename, content)

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -344,7 +344,7 @@ class EnvVars:
                value=$(printenv $v)
                if [ -n "$value" ]
                then
-                   echo export "$v=$value" >> deactivate_{filename}
+                   echo export "$v='$value'" >> deactivate_{filename}
                else
                    echo unset $v >> deactivate_{filename}
                fi

--- a/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -77,11 +77,11 @@ def test_nowinbash_virtual_msys(client):
     client.run("install . -s:b os=Windows -s:h os=Windows")
     assert not os.path.exists(os.path.join(client.current_folder, "conanbuildenv.sh"))
     build_contents = client.load("conanbuildenv.bat")
-    assert 'set AR=c:/path/to/ar' in build_contents
-    assert 'set PATH=%PATH%;c:/path/to/something' in build_contents
+    assert 'set "AR=c:/path/to/ar"' in build_contents
+    assert 'set "PATH=%PATH%;c:/path/to/something"' in build_contents
     assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.sh"))
     run_contents = client.load("conanrunenv.bat")
-    assert "set RUNTIME_VAR=c:/path/to/exe" in run_contents
+    assert 'set "RUNTIME_VAR=c:/path/to/exe"' in run_contents
 
     # BUILD subsystem=msys2 HOST subsystem=None
     client.save({"conanfile.py": conanfile}, clean_first=True)
@@ -92,15 +92,15 @@ def test_nowinbash_virtual_msys(client):
     assert 'export PATH="$PATH:/c/path/to/something"' in build_contents
     assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.sh"))
     run_contents = client.load("conanrunenv.bat")
-    assert "set RUNTIME_VAR=c:/path/to/exe" in run_contents
+    assert 'set "RUNTIME_VAR=c:/path/to/exe"' in run_contents
 
     # BUILD subsystem=None HOST subsystem=msys2
     client.save({"conanfile.py": conanfile}, clean_first=True)
     client.run("install . -s:b os=Windows  -s:h os=Windows -s:h os.subsystem=msys2")
     assert not os.path.exists(os.path.join(client.current_folder, "conanbuildenv.sh"))
     build_contents = client.load("conanbuildenv.bat")
-    assert 'set AR=c:/path/to/ar' in build_contents
-    assert 'set PATH=%PATH%;c:/path/to/something' in build_contents
+    assert 'set "AR=c:/path/to/ar"' in build_contents
+    assert 'set "PATH=%PATH%;c:/path/to/something"' in build_contents
     assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.bat"))
     run_contents = client.load("conanrunenv.sh")
     assert 'export RUNTIME_VAR="/c/path/to/exe"' in run_contents
@@ -129,11 +129,11 @@ def test_nowinbash_virtual_cygwin(client):
     client.run("install . -s:b os=Windows -s:h os=Windows")
     assert not os.path.exists(os.path.join(client.current_folder, "conanbuildenv.sh"))
     build_contents = client.load("conanbuildenv.bat")
-    assert 'set AR=c:/path/to/ar' in build_contents
-    assert 'set PATH=%PATH%;c:/path/to/something' in build_contents
+    assert 'set "AR=c:/path/to/ar"' in build_contents
+    assert 'set "PATH=%PATH%;c:/path/to/something"' in build_contents
     assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.sh"))
     run_contents = client.load("conanrunenv.bat")
-    assert "set RUNTIME_VAR=c:/path/to/exe" in run_contents
+    assert 'set "RUNTIME_VAR=c:/path/to/exe"' in run_contents
 
     # BUILD subsystem=cygwin HOST subsystem=None
     client.save({"conanfile.py": conanfile}, clean_first=True)
@@ -144,15 +144,15 @@ def test_nowinbash_virtual_cygwin(client):
     assert 'export PATH="$PATH:/cygdrive/c/path/to/something"' in build_contents
     assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.sh"))
     run_contents = client.load("conanrunenv.bat")
-    assert "set RUNTIME_VAR=c:/path/to/exe" in run_contents
+    assert 'set "RUNTIME_VAR=c:/path/to/exe"' in run_contents
 
     # BUILD subsystem=None HOST subsystem=cygwin
     client.save({"conanfile.py": conanfile}, clean_first=True)
     client.run("install . -s:b os=Windows  -s:h os=Windows -s:h os.subsystem=cygwin")
     assert not os.path.exists(os.path.join(client.current_folder, "conanbuildenv.sh"))
     build_contents = client.load("conanbuildenv.bat")
-    assert 'set AR=c:/path/to/ar' in build_contents
-    assert 'set PATH=%PATH%;c:/path/to/something' in build_contents
+    assert 'set "AR=c:/path/to/ar"' in build_contents
+    assert 'set "PATH=%PATH%;c:/path/to/something"' in build_contents
     assert not os.path.exists(os.path.join(client.current_folder, "conanrunenv.bat"))
     run_contents = client.load("conanrunenv.sh")
     assert 'export RUNTIME_VAR="/cygdrive/c/path/to/exe"' in run_contents

--- a/conans/test/unittests/tools/env/test_env_files.py
+++ b/conans/test/unittests/tools/env/test_env_files.py
@@ -35,7 +35,7 @@ def prevenv():
         "MyVar1": "OldVar1",
         "MyVar2": "OldVar2",
         "MyVar3": "OldVar3 with spaces",
-        "MyVar4": "OldVar4 with $(some) > special @ characters",
+        "MyVar4": "OldVar4 with $(some) special @ characters",
         "MyPath1": "OldPath1",
         "MyPath2": "OldPath2",
         "MyPath3": "OldPath3",
@@ -65,7 +65,7 @@ def check_env_files_output(cmd_, prevenv):
     assert "MyVar1=OldVar1!!" in out
     assert "MyVar2=OldVar2!!" in out
     assert "MyVar3=OldVar3 with spaces!!" in out
-    assert "MyVar4=OldVar4 with $(some) > special @ characters!!" in out
+    assert "MyVar4=OldVar4 with $(some) special @ characters!!" in out
     assert "MyVar5=!!" in out
     assert "MyVar6=!!" in out
     assert "MyPath1=OldPath1!!" in out
@@ -90,8 +90,8 @@ def test_env_files_bat(env, prevenv):
         echo MyPath3=%MyPath3%!!
         echo MyPath4=%MyPath4%!!
         """)
-
-    with chdir(temp_folder()):
+    t = temp_folder()
+    with chdir(t):
         env = env.vars(ConanFileMock())
         env.save_bat("test.bat")
         save("display.bat", display)

--- a/conans/test/unittests/tools/env/test_env_files.py
+++ b/conans/test/unittests/tools/env/test_env_files.py
@@ -34,8 +34,8 @@ def prevenv():
     return {
         "MyVar1": "OldVar1",
         "MyVar2": "OldVar2",
-        "MyVar3": "OldVar3",
-        "MyVar4": "OldVar4",
+        "MyVar3": "OldVar3 with spaces",
+        "MyVar4": "OldVar4 with $(some) > special @ characters",
         "MyPath1": "OldPath1",
         "MyPath2": "OldPath2",
         "MyPath3": "OldPath3",
@@ -51,7 +51,7 @@ def check_env_files_output(cmd_, prevenv):
     assert "MyVar=MyValue!!" in out
     assert "MyVar1=MyValue1!!" in out
     assert "MyVar2=OldVar2 MyValue2!!" in out
-    assert "MyVar3=MyValue3 OldVar3!!" in out
+    assert "MyVar3=MyValue3 OldVar3 with spaces!!" in out
     assert "MyVar4=!!" in out
     assert "MyVar5=MyValue5 With Space5=More Space5;:More!!" in out
     assert "MyVar6= MyValue6!!" in out  # The previous is non existing, append has space
@@ -64,8 +64,8 @@ def check_env_files_output(cmd_, prevenv):
     assert "MyVar=!!" in out
     assert "MyVar1=OldVar1!!" in out
     assert "MyVar2=OldVar2!!" in out
-    assert "MyVar3=OldVar3!!" in out
-    assert "MyVar4=OldVar4!!" in out
+    assert "MyVar3=OldVar3 with spaces!!" in out
+    assert "MyVar4=OldVar4 with $(some) > special @ characters!!" in out
     assert "MyVar5=!!" in out
     assert "MyVar6=!!" in out
     assert "MyPath1=OldPath1!!" in out

--- a/conans/test/unittests/tools/env/test_env_files.py
+++ b/conans/test/unittests/tools/env/test_env_files.py
@@ -35,7 +35,7 @@ def prevenv():
         "MyVar1": "OldVar1",
         "MyVar2": "OldVar2",
         "MyVar3": "OldVar3 with spaces",
-        "MyVar4": "OldVar4 with $(some) special @ characters",
+        "MyVar4": "OldVar4 with (some) special @ characters",
         "MyPath1": "OldPath1",
         "MyPath2": "OldPath2",
         "MyPath3": "OldPath3",
@@ -45,7 +45,7 @@ def prevenv():
 
 def check_env_files_output(cmd_, prevenv):
     result, _ = subprocess.Popen(cmd_, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            env=prevenv, shell=True).communicate()
+                                 env=prevenv, shell=True).communicate()
     out = result.decode()
 
     assert "MyVar=MyValue!!" in out
@@ -65,7 +65,7 @@ def check_env_files_output(cmd_, prevenv):
     assert "MyVar1=OldVar1!!" in out
     assert "MyVar2=OldVar2!!" in out
     assert "MyVar3=OldVar3 with spaces!!" in out
-    assert "MyVar4=OldVar4 with $(some) special @ characters!!" in out
+    assert "MyVar4=OldVar4 with (some) special @ characters!!" in out
     assert "MyVar5=!!" in out
     assert "MyVar6=!!" in out
     assert "MyPath1=OldPath1!!" in out


### PR DESCRIPTION
**Problem:** Current implementation fails when there are environment variables with spaces in them.

**Reason:** missing quotes

**How to reproduce:**
1. export MYVAR="value with whitespace"
2. conan install with VirtualBuildEnv generator
3. run conanbuild.sh and deactivate_conanbuild.sh
4. deactivate_conanbuild.sh fails

**Fix:** Added quotes

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
